### PR TITLE
H264 support for G45 ("experimental")

### DIFF
--- a/src/i965_device_info.c
+++ b/src/i965_device_info.c
@@ -75,7 +75,7 @@ static struct hw_codec_info g4x_hw_codec_info = {
     .min_linear_hpitch = 4,
 
     .has_mpeg2_decoding = 1,
-
+    .has_h264_decoding = 1,
     .num_filters = 0,
 };
 


### PR DESCRIPTION
Changes from https://bitbucket.org/alium/g45-h264/downloads/intel-driver-g45-h264-2.4.1-experimental.tar.gz